### PR TITLE
Added two news corpus of Kinyarwanda and Kirundi languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,4 +211,4 @@ Alphabetical list of free/public domain datasets with text data for use in Natur
 
 ## Datasets (Kinyarwanda and Kirundi)
 
-*  [KINNEWS and KIRNEWS](https://github.com/Andrews2017/KINNEWS-and-KIRNEWS-Corpus): Two annoatated and cleaned datasets of more than 20k Kinyarwanda and 4k Kirundi news articles. (65 MB)
+*  [KINNEWS and KIRNEWS](https://github.com/Andrews2017/KINNEWS-and-KIRNEWS-Corpus): Two annotated and cleaned datasets of more than 20k Kinyarwanda and 4k Kirundi news articles. (65 MB)

--- a/README.md
+++ b/README.md
@@ -211,4 +211,4 @@ Alphabetical list of free/public domain datasets with text data for use in Natur
 
 ## Datasets (Kinyarwanda and Kirundi)
 
-*  [KINNEWS and KIRNEWS](https://github.com/Andrews2017/KINNEWS-and-KIRNEWS-Corpus): Two annoatated and cleaned datasets of more than 20K Kinyarwanda and more than 4K Kirundi news articles. (65 MB)
+*  [KINNEWS and KIRNEWS](https://github.com/Andrews2017/KINNEWS-and-KIRNEWS-Corpus): Two annoatated and cleaned datasets of more than 20k Kinyarwanda and 4k Kirundi news articles. (65 MB)

--- a/README.md
+++ b/README.md
@@ -209,3 +209,6 @@ Alphabetical list of free/public domain datasets with text data for use in Natur
 
 *   [100k German Court Decisions](http://openlegaldata.io/research/2019/02/19/court-decision-dataset.html): Open Legal Data releases a dataset of 100,000 German court decisions and 444,000 citations (772 MB)
 
+## Datasets (Kinyarwanda)
+
+*  KINNEWS and KIRNEWS

--- a/README.md
+++ b/README.md
@@ -209,6 +209,6 @@ Alphabetical list of free/public domain datasets with text data for use in Natur
 
 *   [100k German Court Decisions](http://openlegaldata.io/research/2019/02/19/court-decision-dataset.html): Open Legal Data releases a dataset of 100,000 German court decisions and 444,000 citations (772 MB)
 
-## Datasets (Kinyarwanda)
+## Datasets (Kinyarwanda and Kirundi)
 
-*  KINNEWS and KIRNEWS
+*  [KINNEWS and KIRNEWS](https://github.com/Andrews2017/KINNEWS-and-KIRNEWS-Corpus): Two annoatated and cleaned datasets of more than 20K Kinyarwanda and more than 4K Kirundi news articles. (65 MB)


### PR DESCRIPTION
Kinyarwanda and Kirundi are low-resource languages belong to Niger-Congo language family. KINNEWS and KIRNEWS are the first news datasets for these languages to go on public. They are well-annotated and cleaned, and raw and cleaned versions are both available. The paper which features these resources was accepted at COLING 2020 and will appear in its proceedings.